### PR TITLE
Add peer by paste / keyserver lookup / QR scan

### DIFF
--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -16,8 +16,12 @@ import type {
     GameDetailDTO,
     SearchResultDTO,
     KeyringStatus,
-    CheckInRecordedDTO
+    CheckInRecordedDTO,
+    PeerImportPreview,
+    PeerImportResult
 } from "../shared/api.js";
+
+const KEYS_OPENPGP_BASE = "https://keys.openpgp.org/vks/v1/by-fingerprint/";
 
 type Handler<T extends (...args: never[]) => unknown> = (
     _event: Electron.IpcMainInvokeEvent,
@@ -144,6 +148,52 @@ export function registerIpcHandlers(): void {
             myVouch: myVouch && !myVouch.revokedAt ? myVouch : null,
             isSelf
         };
+    });
+
+    handle<HomeGamesAPI["peers"]["previewArmored"]>("peers:previewArmored", async (_e, armored) => {
+        const key = await openpgp.readKey({ armoredKey: armored });
+        const fingerprint = key.getFingerprint().toUpperCase();
+        const userIds = key.getUserIDs();
+        return { fingerprint, publicKeyArmored: armored, userIds } satisfies PeerImportPreview;
+    });
+
+    handle<HomeGamesAPI["peers"]["import"]>("peers:import", async (_e, armored) => {
+        const { playerRepo, identityRepo } = getServices();
+        const key = await openpgp.readKey({ armoredKey: armored });
+        const fingerprint = key.getFingerprint().toUpperCase();
+
+        const me = identityRepo.get();
+        if (me?.fingerprint === fingerprint) {
+            throw new Error("That's your own key.");
+        }
+
+        const existing = playerRepo.getByFingerprint(fingerprint);
+        if (existing) {
+            playerRepo.updateLastSeen(fingerprint);
+            return { player: { ...existing, lastSeen: Math.floor(Date.now() / 1000) }, wasNew: false } satisfies PeerImportResult;
+        }
+        const player = playerRepo.create({
+            gpgFingerprint: fingerprint,
+            publicKeyArmored: armored,
+            trustStatus: "untrusted"
+        });
+        return { player, wasNew: true } satisfies PeerImportResult;
+    });
+
+    handle<HomeGamesAPI["peers"]["fetchByFingerprint"]>("peers:fetchByFingerprint", async (_e, fingerprint) => {
+        const normalised = fingerprint.replace(/\s+/g, "").toUpperCase();
+        if (!/^[A-F0-9]{40}$/.test(normalised)) {
+            throw new Error("Invalid fingerprint. Expected 40 hex characters.");
+        }
+        const url = `${KEYS_OPENPGP_BASE}${normalised}`;
+        const res = await fetch(url, { headers: { Accept: "application/pgp-keys" } });
+        if (res.status === 404) {
+            throw new Error("Key not found on keys.openpgp.org. Try paste or QR instead.");
+        }
+        if (!res.ok) {
+            throw new Error(`Keyserver returned ${res.status}.`);
+        }
+        return res.text();
     });
 
     // ─── Vouches ────────────────────────────────────────────────────────

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -14,7 +14,10 @@ const api: HomeGamesAPI = {
     },
     peers: {
         list: () => ipcRenderer.invoke("peers:list"),
-        detail: (fingerprint) => ipcRenderer.invoke("peers:detail", fingerprint)
+        detail: (fingerprint) => ipcRenderer.invoke("peers:detail", fingerprint),
+        previewArmored: (armored) => ipcRenderer.invoke("peers:previewArmored", armored),
+        import: (armored) => ipcRenderer.invoke("peers:import", armored),
+        fetchByFingerprint: (fp) => ipcRenderer.invoke("peers:fetchByFingerprint", fp)
     },
     vouches: {
         listMine: () => ipcRenderer.invoke("vouches:listMine"),

--- a/packages/desktop/src/renderer/components/AddPeerModal.tsx
+++ b/packages/desktop/src/renderer/components/AddPeerModal.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import type { PeerImportPreview } from "../../shared/api";
+import { QRScanner } from "./QRScanner";
+import { formatFp } from "../utils";
+
+type Tab = "paste" | "keyserver" | "qr";
+
+interface Props {
+    onClose: () => void;
+    onAdded: (wasNew: boolean) => void;
+}
+
+export function AddPeerModal({ onClose, onAdded }: Props) {
+    const [tab, setTab] = useState<Tab>("paste");
+    const [armored, setArmored] = useState("");
+    const [fingerprint, setFingerprint] = useState("");
+    const [preview, setPreview] = useState<PeerImportPreview | null>(null);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const reset = () => {
+        setArmored("");
+        setFingerprint("");
+        setPreview(null);
+        setError(null);
+    };
+
+    const tryPreview = async (block: string) => {
+        setBusy(true);
+        setError(null);
+        try {
+            const p = await window.homegames.peers.previewArmored(block);
+            setPreview(p);
+        } catch (err) {
+            setError("Couldn't parse that block. Make sure it starts with -----BEGIN PGP PUBLIC KEY BLOCK-----.");
+            console.error(err);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const fetchAndPreview = async () => {
+        setBusy(true);
+        setError(null);
+        try {
+            const block = await window.homegames.peers.fetchByFingerprint(fingerprint);
+            setArmored(block);
+            await tryPreview(block);
+        } catch (err) {
+            setError((err as Error).message);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleQrScan = async (text: string) => {
+        // QR can carry either an armored block or a bare fingerprint.
+        if (text.includes("BEGIN PGP PUBLIC KEY BLOCK")) {
+            setArmored(text);
+            await tryPreview(text);
+            return;
+        }
+        const stripped = text.replace(/\s+/g, "").toUpperCase();
+        if (/^[A-F0-9]{40}$/.test(stripped)) {
+            setFingerprint(stripped);
+            setBusy(true);
+            try {
+                const block = await window.homegames.peers.fetchByFingerprint(stripped);
+                setArmored(block);
+                await tryPreview(block);
+            } catch (err) {
+                setError((err as Error).message);
+            } finally {
+                setBusy(false);
+            }
+            return;
+        }
+        setError("QR doesn't look like a public key or fingerprint.");
+    };
+
+    const confirmAdd = async () => {
+        if (!armored) return;
+        setBusy(true);
+        setError(null);
+        try {
+            const result = await window.homegames.peers.import(armored);
+            onAdded(result.wasNew);
+        } catch (err) {
+            setError((err as Error).message);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div className="modal-backdrop" onClick={onClose}>
+            <div className="modal" onClick={(e) => e.stopPropagation()} style={{ width: 560 }}>
+                <h3>Add peer</h3>
+
+                {!preview ? (
+                    <>
+                        <div className="toolbar" style={{ marginBottom: 16 }}>
+                            <button className={tab === "paste" ? "primary" : ""} onClick={() => { setTab("paste"); reset(); }}>Paste</button>
+                            <button className={tab === "keyserver" ? "primary" : ""} onClick={() => { setTab("keyserver"); reset(); }}>Keyserver</button>
+                            <button className={tab === "qr" ? "primary" : ""} onClick={() => { setTab("qr"); reset(); }}>QR</button>
+                        </div>
+
+                        {tab === "paste" && (
+                            <>
+                                <p style={{ color: "var(--text-dim)", fontSize: 13, marginTop: -8 }}>
+                                    Paste a public key block someone sent you (WhatsApp, Signal, email…).
+                                </p>
+                                <textarea
+                                    value={armored}
+                                    onChange={(e) => setArmored(e.target.value)}
+                                    rows={10}
+                                    placeholder="-----BEGIN PGP PUBLIC KEY BLOCK-----&#10;…&#10;-----END PGP PUBLIC KEY BLOCK-----"
+                                    style={{ fontFamily: "ui-monospace, monospace", fontSize: 11 }}
+                                />
+                                <div className="actions">
+                                    <button onClick={onClose}>Cancel</button>
+                                    <button className="primary" disabled={busy || !armored.trim()} onClick={() => tryPreview(armored)}>
+                                        {busy ? "Parsing…" : "Preview"}
+                                    </button>
+                                </div>
+                            </>
+                        )}
+
+                        {tab === "keyserver" && (
+                            <>
+                                <p style={{ color: "var(--text-dim)", fontSize: 13, marginTop: -8 }}>
+                                    Look up by GPG fingerprint on keys.openpgp.org. Only finds keys whose owner verified an email.
+                                </p>
+                                <input
+                                    value={fingerprint}
+                                    onChange={(e) => setFingerprint(e.target.value)}
+                                    placeholder="ABCD 1234 5678 …  (40 hex chars, spaces ok)"
+                                    style={{ fontFamily: "ui-monospace, monospace" }}
+                                />
+                                <div className="actions">
+                                    <button onClick={onClose}>Cancel</button>
+                                    <button className="primary" disabled={busy || !fingerprint.trim()} onClick={fetchAndPreview}>
+                                        {busy ? "Fetching…" : "Look up"}
+                                    </button>
+                                </div>
+                            </>
+                        )}
+
+                        {tab === "qr" && (
+                            <>
+                                <p style={{ color: "var(--text-dim)", fontSize: 13, marginTop: -8 }}>
+                                    Scan a QR containing either an armored public key or a fingerprint hex.
+                                </p>
+                                <QRScanner
+                                    onDecoded={handleQrScan}
+                                    onError={(err) => setError((err as Error).message || "Camera error")}
+                                />
+                                <div className="actions">
+                                    <button onClick={onClose}>Cancel</button>
+                                </div>
+                            </>
+                        )}
+
+                        {error && <div className="alert error">{error}</div>}
+                    </>
+                ) : (
+                    <>
+                        <div className="card">
+                            <div className="label">Fingerprint</div>
+                            <div className="mono" style={{ marginTop: 4 }}>{formatFp(preview.fingerprint)}</div>
+                        </div>
+                        {preview.userIds.length > 0 && (
+                            <div className="card">
+                                <div className="label">User IDs</div>
+                                {preview.userIds.map((uid, i) => (
+                                    <div key={i} style={{ marginTop: 4, fontSize: 13 }}>{uid}</div>
+                                ))}
+                            </div>
+                        )}
+
+                        {error && <div className="alert error">{error}</div>}
+
+                        <div className="actions">
+                            <button onClick={() => { setPreview(null); }}>Back</button>
+                            <button className="primary" disabled={busy} onClick={confirmAdd}>
+                                {busy ? "Adding…" : "Add peer"}
+                            </button>
+                        </div>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/packages/desktop/src/renderer/pages/Identity.tsx
+++ b/packages/desktop/src/renderer/pages/Identity.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { IdentitySummary } from "../../shared/api";
 import { formatFp, formatTime } from "../utils";
+import { QRCanvas } from "../components/QRCanvas";
 
 export function IdentityPage() {
     const [identity, setIdentity] = useState<IdentitySummary | null | undefined>(undefined);
@@ -34,16 +35,54 @@ export function IdentityPage() {
             <div className="card">
                 <div className="label">Public key</div>
                 <pre style={{ marginTop: 8 }}>{identity.publicKeyArmored}</pre>
-                <button
-                    style={{ marginTop: 8 }}
-                    onClick={() => navigator.clipboard.writeText(identity.publicKeyArmored)}
-                >
-                    Copy public key
-                </button>
+                <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+                    <button onClick={() => navigator.clipboard.writeText(identity.publicKeyArmored)}>
+                        Copy public key
+                    </button>
+                    <ShowAsQRButton armored={identity.publicKeyArmored} />
+                </div>
             </div>
 
             <DangerZone onDeleted={refresh} />
         </div>
+    );
+}
+
+function ShowAsQRButton({ armored }: { armored: string }) {
+    const [open, setOpen] = useState(false);
+    // Ed25519 public keys armored fit comfortably in a single QR (~700 chars).
+    // RSA 4096 keys are ~3000 chars and overflow QR capacity — surface that
+    // explicitly so the user knows to fall back to copy-paste.
+    const tooBig = armored.length > 1800;
+
+    return (
+        <>
+            <button onClick={() => setOpen(true)}>Show as QR</button>
+            {open && (
+                <div className="modal-backdrop" onClick={() => setOpen(false)}>
+                    <div className="modal" onClick={(e) => e.stopPropagation()}>
+                        <h3>Your public key as QR</h3>
+                        {tooBig ? (
+                            <div className="alert warn">
+                                This key is too large to fit in a single QR. Use 'Copy public key' and paste it instead.
+                            </div>
+                        ) : (
+                            <>
+                                <p style={{ color: "var(--text-dim)", fontSize: 13, marginTop: -8 }}>
+                                    Have your peer scan this from their HomeGames → Peers → Add peer → QR.
+                                </p>
+                                <div style={{ display: "flex", justifyContent: "center", padding: "8px 0 16px" }}>
+                                    <QRCanvas payload={armored} size={300} />
+                                </div>
+                            </>
+                        )}
+                        <div className="actions">
+                            <button onClick={() => setOpen(false)}>Close</button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </>
     );
 }
 

--- a/packages/desktop/src/renderer/pages/Peers.tsx
+++ b/packages/desktop/src/renderer/pages/Peers.tsx
@@ -2,11 +2,14 @@ import { useEffect, useState } from "react";
 import type { Player } from "@homegames/core";
 import { shortFp, formatTime } from "../utils";
 import { PeerDetailModal } from "../components/PeerDetailModal";
+import { AddPeerModal } from "../components/AddPeerModal";
 
 export function PeersPage() {
     const [peers, setPeers] = useState<Player[]>([]);
     const [loading, setLoading] = useState(true);
     const [selected, setSelected] = useState<string | null>(null);
+    const [showAdd, setShowAdd] = useState(false);
+    const [flash, setFlash] = useState<string | null>(null);
 
     const refresh = async () => {
         setLoading(true);
@@ -23,16 +26,19 @@ export function PeersPage() {
             <p className="subtitle">Players whose public keys you've imported. Trust status is computed from vouches.</p>
 
             <div className="toolbar">
+                <button className="primary" onClick={() => setShowAdd(true)}>+ Add peer</button>
                 <button onClick={refresh}>Refresh</button>
                 <div className="spacer" />
                 <span style={{ color: "var(--text-dim)", fontSize: 12 }}>{peers.length} known</span>
             </div>
 
+            {flash && <div className="alert info">{flash}</div>}
+
             {loading ? (
                 <div className="empty">Loading…</div>
             ) : peers.length === 0 ? (
                 <div className="empty">
-                    No peers known yet. Import a public key with the CLI: <span className="kbd">homegames identity import &lt;file&gt;</span>
+                    No peers known yet. Click "+ Add peer" to import one by paste, keyserver lookup, or QR.
                 </div>
             ) : (
                 <table>
@@ -68,6 +74,18 @@ export function PeersPage() {
                     fingerprint={selected}
                     onClose={() => setSelected(null)}
                     onChanged={refresh}
+                />
+            )}
+
+            {showAdd && (
+                <AddPeerModal
+                    onClose={() => setShowAdd(false)}
+                    onAdded={(wasNew) => {
+                        setShowAdd(false);
+                        setFlash(wasNew ? "Peer added." : "Peer already in your list — last seen updated.");
+                        refresh();
+                        setTimeout(() => setFlash(null), 4000);
+                    }}
                 />
             )}
         </div>

--- a/packages/desktop/src/shared/api.ts
+++ b/packages/desktop/src/shared/api.ts
@@ -61,6 +61,17 @@ export interface PeerDetailDTO {
     isSelf: boolean;
 }
 
+export interface PeerImportPreview {
+    fingerprint: string;
+    publicKeyArmored: string;
+    userIds: string[];
+}
+
+export interface PeerImportResult {
+    player: Player;
+    wasNew: boolean;
+}
+
 export interface KeyringStatus {
     unlocked: boolean;
     fingerprint: string | null;
@@ -80,6 +91,9 @@ export interface HomeGamesAPI {
     peers: {
         list: () => Promise<Player[]>;
         detail: (fingerprint: string) => Promise<PeerDetailDTO | null>;
+        previewArmored: (armored: string) => Promise<PeerImportPreview>;
+        import: (armored: string) => Promise<PeerImportResult>;
+        fetchByFingerprint: (fingerprint: string) => Promise<string>;
     };
     vouches: {
         listMine: () => Promise<Vouch[]>;


### PR DESCRIPTION
## Summary
- Adds an 'Add peer' button on the Peers page that opens a tabbed modal: Paste, Keyserver, QR
- Paste accepts an armored \`-----BEGIN PGP PUBLIC KEY BLOCK-----\` block from any source (WhatsApp, Signal, email)
- Keyserver hits \`keys.openpgp.org/vks/v1/by-fingerprint/<HEX>\` with 404 → 'try paste or QR' fallback
- QR scan accepts either an armored block or a bare 40-hex fingerprint (latter triggers keyserver lookup)
- All three tabs converge on a preview screen showing fingerprint + UIDs, then single 'Add peer' confirm
- Duplicate import → updates lastSeen + 'already in your list' flash on page
- Identity page gets 'Show as QR' button (the inverse direction); Ed25519 keys fit a single QR, RSA 4096 overflows and surfaces a clear warning

Three new IPC handlers: \`peers.previewArmored\`, \`peers.import\`, \`peers.fetchByFingerprint\`.

## Test plan
- [ ] Paste tab: paste an armored block, see preview, confirm → peer appears in list
- [ ] Paste tab: paste garbage → clean error
- [ ] Keyserver tab: enter a known-good fingerprint → preview → add
- [ ] Keyserver tab: enter a fingerprint not on the keyserver → 'try paste' message
- [ ] Keyserver tab: enter malformed fingerprint → validation error
- [ ] QR tab: scan a QR containing your other instance's public key (use 'Show as QR' from Identity) → preview → add
- [ ] QR tab: scan a QR containing only a fingerprint hex → triggers keyserver lookup
- [ ] Re-import the same peer → 'already in your list — last seen updated' flash, no duplicate row
- [ ] Identity page → 'Show as QR' renders the local public key as a scannable QR
- [ ] Importing your own key → clean rejection ('That's your own key.')

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)