### PR TITLE
Add I2P network status and Start/Stop controls in the sidebar

### DIFF
--- a/packages/core/src/network/service.ts
+++ b/packages/core/src/network/service.ts
@@ -85,6 +85,21 @@ export class NetworkService extends EventEmitter {
     }
 
     /**
+     * Initialize from an already-decrypted private key. Use this when
+     * the caller (e.g. desktop UI) has an unlocked Keyring and doesn't
+     * want to re-prompt for a passphrase to start the network.
+     */
+    setKeys(
+        fingerprint: string,
+        privateKey: openpgp.PrivateKey,
+        publicKeyArmored: string
+    ): void {
+        this.localFingerprint = fingerprint;
+        this.privateKey = privateKey;
+        this.publicKeyArmored = publicKeyArmored;
+    }
+
+    /**
      * Start the network service
      */
     async start(): Promise<void> {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -50,10 +50,10 @@ app.whenReady().then(() => {
 });
 
 app.on("window-all-closed", () => {
-    shutdownServices();
+    shutdownServices().catch(() => { /* ignore */ });
     if (process.platform !== "darwin") app.quit();
 });
 
 app.on("before-quit", () => {
-    shutdownServices();
+    shutdownServices().catch(() => { /* ignore */ });
 });

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -7,7 +7,9 @@ import {
     searchListings,
     timestampNow,
     GamePublicData,
-    GameListing
+    GameListing,
+    NetworkService,
+    NetworkStatus
 } from "@homegames/core";
 import { getServices } from "./services.js";
 import type {
@@ -18,7 +20,9 @@ import type {
     KeyringStatus,
     CheckInRecordedDTO,
     PeerImportPreview,
-    PeerImportResult
+    PeerImportResult,
+    NetworkStatusDTO,
+    NetworkStateLabel
 } from "../shared/api.js";
 
 const KEYS_OPENPGP_BASE = "https://keys.openpgp.org/vks/v1/by-fingerprint/";
@@ -352,5 +356,82 @@ export function registerIpcHandlers(): void {
     handle<HomeGamesAPI["checkins"]["listForGame"]>("checkins:listForGame", async (_e, gameListingId) => {
         const { checkinService } = getServices();
         return checkinService.getForGame(gameListingId);
+    });
+
+    // ─── Network ────────────────────────────────────────────────────────
+    function readStatus(): NetworkStatusDTO {
+        const services = getServices();
+        const svc = services.networkService;
+        if (!svc) {
+            return {
+                state: services.networkLastError ? "error" : "disconnected",
+                destinationBase32: null,
+                destinationBase64: null,
+                peerCount: 0,
+                lastError: services.networkLastError
+            };
+        }
+        const dest = svc.getDestination();
+        const raw = svc.getStatus();
+        const state: NetworkStateLabel =
+            raw === NetworkStatus.CONNECTED ? "connected"
+            : raw === NetworkStatus.CONNECTING ? "connecting"
+            : raw === NetworkStatus.ERROR ? "error"
+            : "disconnected";
+        return {
+            state,
+            destinationBase32: dest?.base32 ?? null,
+            destinationBase64: dest?.base64 ?? null,
+            peerCount: svc.getConnectedPeerCount(),
+            lastError: services.networkLastError
+        };
+    }
+
+    handle<HomeGamesAPI["network"]["status"]>("network:status", async () => readStatus());
+
+    handle<HomeGamesAPI["network"]["start"]>("network:start", async () => {
+        const services = getServices();
+        if (services.networkService) return readStatus();
+
+        const { keyring, identityRepo, db, gameService, rsvpService } = services;
+        const me = identityRepo.get();
+        if (!me) throw new Error("No identity. Create one first.");
+        if (!keyring.isUnlocked()) {
+            throw new Error("Identity is locked. Unlock to start the network.");
+        }
+        const privateKey = keyring.getPrivateKey();
+        if (!privateKey) throw new Error("No private key in keyring.");
+
+        services.setNetworkLastError(null);
+        const svc = new NetworkService(db.getConnection());
+        svc.setKeys(me.fingerprint, privateKey, me.publicKey);
+
+        // Surface async errors (i2pd not running, lost connection)
+        // through the cached lastError so the sidebar polling can show them.
+        svc.on("error", (err: Error) => {
+            services.setNetworkLastError(err.message);
+        });
+
+        try {
+            await svc.start();
+            svc.attachGameHandler(gameService, rsvpService, keyring);
+            services.setNetworkService(svc);
+        } catch (err) {
+            services.setNetworkLastError((err as Error).message);
+            await svc.stop().catch(() => { /* ignore */ });
+            throw err;
+        }
+        return readStatus();
+    });
+
+    handle<HomeGamesAPI["network"]["stop"]>("network:stop", async () => {
+        const services = getServices();
+        const svc = services.networkService;
+        if (svc) {
+            await svc.stop();
+            services.setNetworkService(null);
+        }
+        services.setNetworkLastError(null);
+        return readStatus();
     });
 }

--- a/packages/desktop/src/main/services.ts
+++ b/packages/desktop/src/main/services.ts
@@ -12,7 +12,8 @@ import {
     VouchService,
     GameService,
     RSVPService,
-    CheckInService
+    CheckInService,
+    NetworkService
 } from "@homegames/core";
 
 export interface AppServices {
@@ -30,6 +31,10 @@ export interface AppServices {
     gameService: GameService;
     rsvpService: RSVPService;
     checkinService: CheckInService;
+    networkService: NetworkService | null;
+    networkLastError: string | null;
+    setNetworkService: (svc: NetworkService | null) => void;
+    setNetworkLastError: (err: string | null) => void;
 }
 
 let cached: AppServices | null = null;
@@ -54,7 +59,7 @@ export function getServices(): AppServices {
     const rsvpService = new RSVPService(rsvpRepo, gameRepo, playerRepo, keyring);
     const checkinService = new CheckInService(checkinRepo, gameRepo, playerRepo, keyring);
 
-    cached = {
+    const services: AppServices = {
         db,
         keyring,
         playerRepo,
@@ -68,8 +73,17 @@ export function getServices(): AppServices {
         vouchService,
         gameService,
         rsvpService,
-        checkinService
+        checkinService,
+        networkService: null,
+        networkLastError: null,
+        setNetworkService: (svc) => {
+            services.networkService = svc;
+        },
+        setNetworkLastError: (err) => {
+            services.networkLastError = err;
+        }
     };
+    cached = services;
 
     // Eagerly load the public key so the sidebar can show your
     // fingerprint without forcing an unlock first. The private key
@@ -82,8 +96,12 @@ export function getServices(): AppServices {
     return cached;
 }
 
-export function shutdownServices(): void {
+export async function shutdownServices(): Promise<void> {
     if (cached) {
+        if (cached.networkService) {
+            await cached.networkService.stop().catch(() => { /* ignore */ });
+            cached.networkService = null;
+        }
         cached.keyring.lock();
         cached.db.close();
         cached = null;

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -36,6 +36,11 @@ const api: HomeGamesAPI = {
         signChallenge: (challenge) => ipcRenderer.invoke("checkins:signChallenge", challenge),
         verifyAndRecord: (challenge, response) => ipcRenderer.invoke("checkins:verifyAndRecord", challenge, response),
         listForGame: (gameListingId) => ipcRenderer.invoke("checkins:listForGame", gameListingId)
+    },
+    network: {
+        status: () => ipcRenderer.invoke("network:status"),
+        start: () => ipcRenderer.invoke("network:start"),
+        stop: () => ipcRenderer.invoke("network:stop")
     }
 };
 

--- a/packages/desktop/src/renderer/components/NetworkPanel.tsx
+++ b/packages/desktop/src/renderer/components/NetworkPanel.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from "react";
+import type { NetworkStatusDTO } from "../../shared/api";
+import { UnlockModal } from "./UnlockModal";
+
+const POLL_MS = 3000;
+
+const STATE_LABEL: Record<NetworkStatusDTO["state"], string> = {
+    disconnected: "Offline",
+    connecting: "Connecting…",
+    connected: "Online",
+    error: "Error"
+};
+
+const STATE_COLOR: Record<NetworkStatusDTO["state"], string> = {
+    disconnected: "var(--text-dim)",
+    connecting: "var(--warn)",
+    connected: "var(--success)",
+    error: "var(--danger)"
+};
+
+export function NetworkPanel() {
+    const [status, setStatus] = useState<NetworkStatusDTO | null>(null);
+    const [busy, setBusy] = useState(false);
+    const [needsUnlock, setNeedsUnlock] = useState(false);
+    const [showDetails, setShowDetails] = useState(false);
+    const [actionError, setActionError] = useState<string | null>(null);
+
+    const refresh = async () => {
+        try {
+            const s = await window.homegames.network.status();
+            setStatus(s);
+        } catch { /* ignore */ }
+    };
+
+    useEffect(() => {
+        refresh();
+        const id = setInterval(refresh, POLL_MS);
+        return () => clearInterval(id);
+    }, []);
+
+    const startAfterUnlock = async () => {
+        setBusy(true);
+        setActionError(null);
+        try {
+            const s = await window.homegames.network.start();
+            setStatus(s);
+        } catch (err) {
+            setActionError((err as Error).message);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const start = async () => {
+        const k = await window.homegames.keyring.status();
+        if (!k.fingerprint) {
+            setActionError("Create an identity first.");
+            return;
+        }
+        if (!k.unlocked) {
+            setNeedsUnlock(true);
+            return;
+        }
+        await startAfterUnlock();
+    };
+
+    const stop = async () => {
+        setBusy(true);
+        setActionError(null);
+        try {
+            const s = await window.homegames.network.stop();
+            setStatus(s);
+        } catch (err) {
+            setActionError((err as Error).message);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    if (!status) return null;
+
+    const isOnline = status.state === "connected";
+    const isStopping = busy && status.state === "connected";
+    const isStarting = busy && status.state !== "connected";
+
+    return (
+        <>
+            <div style={{ borderTop: "1px solid var(--border)", padding: "8px 16px" }}>
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", cursor: "pointer" }}
+                     onClick={() => setShowDetails(true)}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                        <span style={{
+                            width: 8, height: 8, borderRadius: 4,
+                            background: STATE_COLOR[status.state],
+                            display: "inline-block",
+                            flexShrink: 0
+                        }} />
+                        <span style={{ fontSize: 11, color: "var(--text-dim)", textTransform: "uppercase", letterSpacing: "0.05em" }}>Network</span>
+                    </div>
+                    <span style={{ fontSize: 11, color: STATE_COLOR[status.state] }}>
+                        {STATE_LABEL[status.state]}
+                        {isOnline && status.peerCount > 0 && ` · ${status.peerCount}`}
+                    </span>
+                </div>
+
+                <div style={{ marginTop: 6 }}>
+                    {!isOnline ? (
+                        <button
+                            onClick={start}
+                            disabled={busy}
+                            style={{ width: "100%", fontSize: 11, padding: "4px 8px" }}
+                        >
+                            {isStarting ? "Starting…" : "Start network"}
+                        </button>
+                    ) : (
+                        <button
+                            onClick={stop}
+                            disabled={busy}
+                            style={{ width: "100%", fontSize: 11, padding: "4px 8px" }}
+                        >
+                            {isStopping ? "Stopping…" : "Stop"}
+                        </button>
+                    )}
+                </div>
+
+                {(actionError || status.lastError) && (
+                    <div style={{ marginTop: 6, fontSize: 11, color: "var(--danger)" }}>
+                        {actionError || status.lastError}
+                    </div>
+                )}
+            </div>
+
+            {needsUnlock && (
+                <UnlockModal
+                    onClose={() => setNeedsUnlock(false)}
+                    onUnlocked={() => { setNeedsUnlock(false); startAfterUnlock(); }}
+                />
+            )}
+
+            {showDetails && (
+                <div className="modal-backdrop" onClick={() => setShowDetails(false)}>
+                    <div className="modal" onClick={(e) => e.stopPropagation()}>
+                        <h3>I2P Network</h3>
+                        <div className="card">
+                            <div className="row">
+                                <div className="label">Status</div>
+                                <div style={{ color: STATE_COLOR[status.state] }}>{STATE_LABEL[status.state]}</div>
+                            </div>
+                            <div className="row" style={{ marginTop: 4 }}>
+                                <div className="label">Connected peers</div>
+                                <div>{status.peerCount}</div>
+                            </div>
+                        </div>
+
+                        {status.destinationBase32 && (
+                            <div className="card">
+                                <div className="label">Your I2P address</div>
+                                <div className="mono" style={{ marginTop: 4, fontSize: 12 }}>
+                                    {status.destinationBase32}
+                                </div>
+                                <button
+                                    style={{ marginTop: 8 }}
+                                    onClick={() => navigator.clipboard.writeText(status.destinationBase32!)}
+                                >
+                                    Copy address
+                                </button>
+                            </div>
+                        )}
+
+                        {!isOnline && (
+                            <div className="alert info">
+                                Networking requires <span className="kbd">i2pd</span> running locally with the SAM bridge enabled (port 7656).
+                                On macOS: <span className="kbd">brew install i2pd</span> then <span className="kbd">i2pd</span> in a terminal. First boot takes a few minutes to reach the I2P network.
+                            </div>
+                        )}
+
+                        {status.lastError && (
+                            <div className="alert error">{status.lastError}</div>
+                        )}
+
+                        <div className="actions">
+                            <button onClick={() => setShowDetails(false)}>Close</button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+}

--- a/packages/desktop/src/renderer/components/Sidebar.tsx
+++ b/packages/desktop/src/renderer/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { shortFp } from "../utils";
+import { NetworkPanel } from "./NetworkPanel";
 import type { KeyringStatus } from "../../shared/api";
 
 export type Page = "identity" | "peers" | "games";
@@ -36,6 +37,7 @@ export function Sidebar({ page, onNavigate }: Props) {
                 <button className={`nav-item ${page === "peers" ? "active" : ""}`} onClick={() => onNavigate("peers")}>Peers</button>
                 <button className={`nav-item ${page === "identity" ? "active" : ""}`} onClick={() => onNavigate("identity")}>Identity</button>
             </nav>
+            <NetworkPanel />
             <div className="footer">
                 {status.fingerprint ? (
                     <>

--- a/packages/desktop/src/shared/api.ts
+++ b/packages/desktop/src/shared/api.ts
@@ -77,6 +77,16 @@ export interface KeyringStatus {
     fingerprint: string | null;
 }
 
+export type NetworkStateLabel = "disconnected" | "connecting" | "connected" | "error";
+
+export interface NetworkStatusDTO {
+    state: NetworkStateLabel;
+    destinationBase32: string | null;
+    destinationBase64: string | null;
+    peerCount: number;
+    lastError: string | null;
+}
+
 export interface HomeGamesAPI {
     identity: {
         get: () => Promise<IdentitySummary | null>;
@@ -124,6 +134,11 @@ export interface HomeGamesAPI {
             response: CheckInResponse
         ) => Promise<CheckInRecordedDTO>;
         listForGame: (gameListingId: string) => Promise<CheckIn[]>;
+    };
+    network: {
+        status: () => Promise<NetworkStatusDTO>;
+        start: () => Promise<NetworkStatusDTO>;
+        stop: () => Promise<NetworkStatusDTO>;
     };
 }
 


### PR DESCRIPTION
## Summary
- Sidebar now shows a coloured dot + label (Offline / Connecting / Online · N peers / Error) with a Start/Stop button
- Click the row → details modal with status, peer count, full b32 I2P address, and an inline tip about i2pd setup
- Brings NetworkService into the desktop main process; previously the desktop had no networking at all

## Key bits
- New \`NetworkService.setKeys()\` core helper lets us start the network from an already-unlocked Keyring without re-prompting for a passphrase
- \`network:start\` IPC requires unlock first (UnlockModal pops automatically), then calls \`attachGameHandler\` so listings + pending RSVPs propagate
- \`lastError\` is cached and surfaced to the sidebar so e.g. 'i2pd not reachable' shows in red without crashing the UI

## Test plan
- [ ] Sidebar shows 'Offline' on cold start
- [ ] Clicking 'Start network' with a locked keyring pops UnlockModal, then proceeds
- [ ] With i2pd not running, error surfaces as 'Error' state with the connection failure in red
- [ ] With i2pd running, transitions Offline → Connecting → Online with peer count
- [ ] Click the row → details modal shows the b32 I2P address; copy works
- [ ] 'Stop' returns to Offline cleanly
- [ ] Quitting the app while online stops the service (no orphaned tunnels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)